### PR TITLE
feat: debugging enhancements, fix ready states

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -26,26 +26,23 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v5.3.0
-  lint:
+
+  prek:
+    name: Run prek checks
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version:
-          - "3.14"
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - name: Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
-          enable-cache: true
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Dependencies
-        run: uv sync --all-extras
-        shell: bash
-      - uses: pre-commit/action@v3.0.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #6.2.0
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - name: Run prek
+        uses: j178/prek-action@cbc2f23eb5539cf20d82d1aabd0d0ecbcc56f4e3 #v2.0.2
 
   test:
     strategy:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,10 @@
   "python.analysis.typeCheckingMode": "basic",
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",
-    "editor.formatOnSave": true
-  }
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    }
+  },
+  "ruff.organizeImports": true
 }

--- a/pyomnilogic_local/_base.py
+++ b/pyomnilogic_local/_base.py
@@ -9,6 +9,7 @@ from pyomnilogic_local.omnitypes import BackyardState
 
 if TYPE_CHECKING:
     from pyomnilogic_local.api.api import OmniLogicAPI
+    from pyomnilogic_local.api.mock_api import OmniLogicMockAPI
     from pyomnilogic_local.models import Telemetry
     from pyomnilogic_local.omnilogic import OmniLogic
 
@@ -72,7 +73,7 @@ class OmniEquipment[MSPConfigT: MSPEquipmentType, TelemetryT: TelemetryType | No
         self.update(mspconfig, telemetry)
 
     @property
-    def _api(self) -> OmniLogicAPI:
+    def _api(self) -> OmniLogicAPI | OmniLogicMockAPI:
         """Access the OmniLogic API through the parent controller."""
         return self._omni._api
 

--- a/pyomnilogic_local/api/mock_api.py
+++ b/pyomnilogic_local/api/mock_api.py
@@ -1,0 +1,88 @@
+"""Mock API for simulation mode — loads data from a local JSON file instead of a live controller."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Literal, overload
+
+from pyomnilogic_local.models.mspconfig import MSPConfig
+from pyomnilogic_local.models.telemetry import Telemetry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class OmniLogicMockAPI:
+    """Drop-in replacement for OmniLogicAPI that serves pre-recorded data from a JSON file.
+
+    The JSON file must contain the simulation data at the paths:
+        - ``.data.telemetry``  — raw XML telemetry string
+        - ``.data.msp_config`` — raw XML MSP config string
+
+    Any API call other than ``async_get_telemetry`` or ``async_get_mspconfig`` is silently
+    absorbed and logged at INFO level; no network traffic is generated.
+    """
+
+    def __init__(self, filepath: str) -> None:
+        """Load simulation data from *filepath*.
+
+        Args:
+            filepath: Path to the JSON simulation data file.
+
+        Raises:
+            FileNotFoundError: If the file does not exist at *filepath*.
+            KeyError: If the expected JSON structure is not present in the file.
+        """
+        path = Path(filepath)
+        if not path.exists():
+            msg = f"Simulation data file not found: {filepath}"
+            raise FileNotFoundError(msg)
+
+        data = json.loads(path.read_text(encoding="utf-8"))
+        sim_data: dict[str, Any] = data["data"]
+
+        self._mspconfig = sim_data["msp_config"]
+        self._telemetry = sim_data["telemetry"]
+
+        _LOGGER.warning(
+            "Running in simulation mode using data from '%s'. No API calls will be made to the OmniLogic controller.",
+            filepath,
+        )
+
+    @overload
+    async def async_get_mspconfig(self, raw: Literal[True]) -> str: ...
+    @overload
+    async def async_get_mspconfig(self, raw: Literal[False]) -> MSPConfig: ...
+    @overload
+    async def async_get_mspconfig(self) -> MSPConfig: ...
+    async def async_get_mspconfig(self, raw: bool = False) -> MSPConfig | str:
+        """Return the pre-loaded MSP config from the simulation file."""
+        if raw:
+            return self._mspconfig
+        return MSPConfig.load_xml(self._mspconfig)
+
+    @overload
+    async def async_get_telemetry(self, raw: Literal[True]) -> str: ...
+    @overload
+    async def async_get_telemetry(self, raw: Literal[False]) -> Telemetry: ...
+    @overload
+    async def async_get_telemetry(self) -> Telemetry: ...
+    async def async_get_telemetry(self, raw: bool = False) -> Telemetry | str:
+        """Return the pre-loaded telemetry from the simulation file."""
+        if raw:
+            return self._telemetry
+        return Telemetry.load_xml(self._telemetry)
+
+    def __getattr__(self, name: str) -> Any:
+        """Return a no-op async callable for any API method not explicitly implemented."""
+
+        async def _noop(*args: Any, **kwargs: Any) -> None:
+            _LOGGER.info(
+                "Simulation mode: ignoring call to %s (args=%s, kwargs=%s)",
+                name,
+                args,
+                kwargs,
+            )
+
+        return _noop

--- a/pyomnilogic_local/chlorinator.py
+++ b/pyomnilogic_local/chlorinator.py
@@ -333,29 +333,6 @@ class Chlorinator(OmniEquipment[MSPChlorinator, TelemetryChlorinator]):
             return "LOW"
         return "OK"
 
-    @property
-    def is_ready(self) -> bool:
-        """Check if the chlorinator is ready to accept commands.
-
-        A chlorinator is considered ready if:
-        - The backyard is not in service/config mode (checked by parent class)
-        - It is authenticated
-        - It has no critical errors that would prevent it from operating
-
-        Returns:
-            True if chlorinator can accept commands, False otherwise
-
-        Example:
-            >>> if chlorinator.is_ready:
-            ...     await chlorinator.set_chlorine_level(75)
-        """
-        # First check if backyard is ready
-        if not super().is_ready:
-            return False
-
-        # Then check chlorinator-specific readiness
-        return self.is_authenticated and not self.has_error
-
     # Control methods
     @control_method
     async def turn_on(self) -> None:

--- a/pyomnilogic_local/cli/__init__.py
+++ b/pyomnilogic_local/cli/__init__.py
@@ -3,9 +3,3 @@
 This module provides the command-line interface for controlling Hayward
 OmniLogic and OmniHub pool controllers.
 """
-
-from __future__ import annotations
-
-from pyomnilogic_local.cli.utils import ensure_connection
-
-__all__ = ["ensure_connection"]

--- a/pyomnilogic_local/cli/cli.py
+++ b/pyomnilogic_local/cli/cli.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import asyncio
+
 import click
 
+from pyomnilogic_local import OmniLogic
 from pyomnilogic_local.cli.debug import commands as debug
 from pyomnilogic_local.cli.get import commands as get
 
@@ -9,7 +12,9 @@ from pyomnilogic_local.cli.get import commands as get
 @click.group()
 @click.pass_context
 @click.option("--host", default="127.0.0.1", help="Hostname or IP address of OmniLogic system (default: 127.0.0.1)")
-def entrypoint(ctx: click.Context, host: str) -> None:
+@click.option("--port", default=10444, help="Port number of OmniLogic system (default: 10444)")
+@click.option("--timeout", default=5, help="Timeout duration for connecting to OmniLogic system in seconds (default: 5)")
+def entrypoint(ctx: click.Context, host: str, port: int, timeout: int) -> None:
     """OmniLogic Local Control - Command line interface for Hayward pool controllers.
 
     This CLI provides local control and monitoring of Hayward OmniLogic and OmniHub
@@ -34,6 +39,13 @@ def entrypoint(ctx: click.Context, host: str) -> None:
 
     # Store the host for later connection, but don't connect yet
     ctx.obj["HOST"] = host
+    ctx.obj["PORT"] = port
+    ctx.obj["TIMEOUT"] = timeout
+    omnilogic = OmniLogic(host, port, timeout)  # Store the OmniLogic instance for later use
+
+    asyncio.run(omnilogic.refresh(force=True))
+
+    ctx.obj["OMNILOGIC"] = omnilogic
 
     # If no subcommand was provided, show help and exit
     if ctx.invoked_subcommand is None:

--- a/pyomnilogic_local/cli/debug/commands.py
+++ b/pyomnilogic_local/cli/debug/commands.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, cast
 import click
 
 from pyomnilogic_local.cli.pcap_utils import parse_pcap_file, process_pcap_messages
-from pyomnilogic_local.cli.utils import async_get_filter_diagnostics
 
 if TYPE_CHECKING:
     from pyomnilogic_local import OmniLogic
@@ -65,46 +64,6 @@ def get_telemetry(ctx: click.Context) -> None:
     omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
     telemetry = asyncio.run(omnilogic._api.async_get_telemetry(raw=ctx.obj["RAW"]))
     click.echo(telemetry)
-
-
-@debug.command()
-@click.option(
-    "--pool-id", required=True, type=int, help="System ID of the Body Of Water the filter is associated with. Example: --pool-id 1"
-)
-@click.option("--filter-id", required=True, type=int, help="System ID of the filter to request diagnostics for. Example: --filter-id 5")
-@click.pass_context
-def get_filter_diagnostics(ctx: click.Context, pool_id: int, filter_id: int) -> None:
-    """Get diagnostic information for a specific filter/pump.
-
-    This command retrieves detailed diagnostic data including firmware versions,
-    power consumption, and error status for a filter or pump.
-
-    Example:
-        omnilogic debug get-filter-diagnostics --pool-id 1 --filter-id 5
-
-    """
-    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
-    filter_diags = asyncio.run(async_get_filter_diagnostics(omnilogic._api, pool_id, filter_id, ctx.obj["RAW"]))
-    if ctx.obj["RAW"]:
-        click.echo(filter_diags)
-    else:
-        drv1 = chr(filter_diags.get_param_by_name("DriveFWRevisionB1"))
-        drv2 = chr(filter_diags.get_param_by_name("DriveFWRevisionB2"))
-        drv3 = chr(filter_diags.get_param_by_name("DriveFWRevisionB3"))
-        drv4 = chr(filter_diags.get_param_by_name("DriveFWRevisionB4"))
-        dfw1 = chr(filter_diags.get_param_by_name("DisplayFWRevisionB1"))
-        dfw2 = chr(filter_diags.get_param_by_name("DisplayFWRevisionB2"))
-        dfw3 = chr(filter_diags.get_param_by_name("DisplayFWRevisionB3"))
-        dfw4 = chr(filter_diags.get_param_by_name("DisplayFWRevisionB4"))
-        pow1 = filter_diags.get_param_by_name("PowerMSB")
-        pow2 = filter_diags.get_param_by_name("PowerLSB")
-        errs = filter_diags.get_param_by_name("ErrorStatus")
-        click.echo(
-            f"DRIVE FW REV: {drv1}{drv2}.{drv3}{drv4}\n"
-            f"DISPLAY FW REV: {dfw1}{dfw2}.{dfw3}.{dfw4}\n"
-            f"POWER: {pow1:x}{pow2:x}W\n"
-            f"ERROR STATUS: {errs}"
-        )
 
 
 @debug.command()

--- a/pyomnilogic_local/cli/debug/commands.py
+++ b/pyomnilogic_local/cli/debug/commands.py
@@ -9,12 +9,11 @@ from typing import TYPE_CHECKING, cast
 
 import click
 
-from pyomnilogic_local.cli import ensure_connection
 from pyomnilogic_local.cli.pcap_utils import parse_pcap_file, process_pcap_messages
 from pyomnilogic_local.cli.utils import async_get_filter_diagnostics
 
 if TYPE_CHECKING:
-    from pyomnilogic_local.api.api import OmniLogicAPI
+    from pyomnilogic_local import OmniLogic
     from pyomnilogic_local.models.telemetry import TelemetryChlorinator
 
 
@@ -45,9 +44,8 @@ def get_mspconfig(ctx: click.Context) -> None:
         omnilogic debug --raw get-mspconfig
 
     """
-    ensure_connection(ctx)
-    omni: OmniLogicAPI = ctx.obj["OMNI"]
-    mspconfig = asyncio.run(omni.async_get_mspconfig(raw=ctx.obj["RAW"]))
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
+    mspconfig = asyncio.run(omnilogic._api.async_get_mspconfig(raw=ctx.obj["RAW"]))
     click.echo(mspconfig)
 
 
@@ -64,9 +62,8 @@ def get_telemetry(ctx: click.Context) -> None:
         omnilogic debug --raw get-telemetry
 
     """
-    ensure_connection(ctx)
-    omni: OmniLogicAPI = ctx.obj["OMNI"]
-    telemetry = asyncio.run(omni.async_get_telemetry(raw=ctx.obj["RAW"]))
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
+    telemetry = asyncio.run(omnilogic._api.async_get_telemetry(raw=ctx.obj["RAW"]))
     click.echo(telemetry)
 
 
@@ -86,8 +83,8 @@ def get_filter_diagnostics(ctx: click.Context, pool_id: int, filter_id: int) -> 
         omnilogic debug get-filter-diagnostics --pool-id 1 --filter-id 5
 
     """
-    ensure_connection(ctx)
-    filter_diags = asyncio.run(async_get_filter_diagnostics(ctx.obj["OMNI"], pool_id, filter_id, ctx.obj["RAW"]))
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
+    filter_diags = asyncio.run(async_get_filter_diagnostics(omnilogic._api, pool_id, filter_id, ctx.obj["RAW"]))
     if ctx.obj["RAW"]:
         click.echo(filter_diags)
     else:
@@ -179,8 +176,7 @@ def set_equipment(ctx: click.Context, bow_id: int, equip_id: int, is_on: str) ->
         omnilogic --host 192.168.1.100 debug set-equipment 7 8 0
 
     """
-    ensure_connection(ctx)
-    omni: OmniLogicAPI = ctx.obj["OMNI"]
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
 
     is_on_value: int | bool | str
     # Parse is_on parameter - can be bool-like string or integer
@@ -194,7 +190,7 @@ def set_equipment(ctx: click.Context, bow_id: int, equip_id: int, is_on: str) ->
 
     # Execute the command
     try:
-        asyncio.run(omni.async_set_equipment(bow_id, equip_id, is_on_value))
+        asyncio.run(omnilogic._api.async_set_equipment(bow_id, equip_id, is_on_value))
         if isinstance(is_on_value, bool):
             state = "ON" if is_on_value else "OFF"
             click.echo(f"Successfully set equipment {equip_id} in BOW {bow_id} to {state}")
@@ -232,8 +228,7 @@ def set_chlor_params(ctx: click.Context, bow_id: int, equip_id: int, timed_perce
         omnilogic --host 192.168.1.100 debug set-chlor-params 7 12 50 2
 
     """
-    ensure_connection(ctx)
-    omni: OmniLogicAPI = ctx.obj["OMNI"]
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
 
     # Validate timed_percent
     if not 0 <= timed_percent <= 1000:  # Temporarily allow up to 1000 to test ORP behavior
@@ -247,8 +242,8 @@ def set_chlor_params(ctx: click.Context, bow_id: int, equip_id: int, timed_perce
 
     # Get MSPConfig and Telemetry to find the chlorinator
     try:
-        mspconfig_raw = asyncio.run(omni.async_get_mspconfig(raw=False))
-        telemetry_raw = asyncio.run(omni.async_get_telemetry(raw=False))
+        mspconfig_raw = asyncio.run(omnilogic._api.async_get_mspconfig(raw=False))
+        telemetry_raw = asyncio.run(omnilogic._api.async_get_telemetry(raw=False))
     except Exception as e:
         click.echo(f"Error retrieving configuration: {e}", err=True)
         raise click.Abort from e
@@ -294,7 +289,7 @@ def set_chlor_params(ctx: click.Context, bow_id: int, equip_id: int, timed_perce
     # Execute the command
     try:
         asyncio.run(
-            omni.async_set_chlorinator_params(
+            omnilogic._api.async_set_chlorinator_params(
                 pool_id=bow_id,
                 equipment_id=equip_id,
                 timed_percent=timed_percent,
@@ -343,8 +338,7 @@ def set_csad_ph(ctx: click.Context, bow_id: int, csad_id: int, target: float) ->
         omnilogic --host 192.168.1.100 debug set-csad-ph 7 20 7.2
 
     """
-    ensure_connection(ctx)
-    omni: OmniLogicAPI = ctx.obj["OMNI"]
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
 
     # Validate target pH (typical range is 6.8-8.2, but allow wider range)
     if not 0.0 <= target <= 14.0:
@@ -353,7 +347,7 @@ def set_csad_ph(ctx: click.Context, bow_id: int, csad_id: int, target: float) ->
 
     # Execute the command
     try:
-        asyncio.run(omni.async_set_csad_target_value(pool_id=bow_id, csad_id=csad_id, ph_target=target))
+        asyncio.run(omnilogic._api.async_set_csad_target_value(pool_id=bow_id, csad_id=csad_id, ph_target=target))
         click.echo(f"Successfully set CSAD {csad_id} in BOW {bow_id} pH target to {target}")
     except Exception as e:
         click.echo(f"Error setting CSAD pH target: {e}", err=True)
@@ -383,8 +377,7 @@ def set_csad_orp(ctx: click.Context, bow_id: int, csad_id: int, target: int) -> 
         omnilogic --host 192.168.1.100 debug set-csad-orp 7 20 650
 
     """
-    ensure_connection(ctx)
-    omni: OmniLogicAPI = ctx.obj["OMNI"]
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
 
     # Validate target ORP (typical range is 400-900 mV, but allow 0-1000)
     if not 0 <= target <= 1000:
@@ -393,7 +386,7 @@ def set_csad_orp(ctx: click.Context, bow_id: int, csad_id: int, target: int) -> 
 
     # Execute the command
     try:
-        asyncio.run(omni.async_set_csad_orp_target_level(pool_id=bow_id, csad_id=csad_id, orp_target=target))
+        asyncio.run(omnilogic._api.async_set_csad_orp_target_level(pool_id=bow_id, csad_id=csad_id, orp_target=target))
         click.echo(f"Successfully set CSAD {csad_id} in BOW {bow_id} ORP target to {target} mV")
     except Exception as e:
         click.echo(f"Error setting CSAD ORP target: {e}", err=True)

--- a/pyomnilogic_local/cli/get/backyard.py
+++ b/pyomnilogic_local/cli/get/backyard.py
@@ -7,9 +7,11 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from pyomnilogic_local.cli.utils import echo_properties
 from pyomnilogic_local.omnitypes import BackyardState
 
 if TYPE_CHECKING:
+    from pyomnilogic_local import OmniLogic
     from pyomnilogic_local.models.mspconfig import MSPBackyard, MSPConfig
     from pyomnilogic_local.models.telemetry import Telemetry, TelemetryType
 
@@ -26,10 +28,8 @@ def backyard(ctx: click.Context) -> None:
     Example:
         omnilogic get backyard
     """
-    mspconfig: MSPConfig = ctx.obj["MSPCONFIG"]
-    telemetry: Telemetry = ctx.obj["TELEMETRY"]
-
-    _print_backyard_info(mspconfig.backyard, telemetry.get_telem_by_systemid(mspconfig.backyard.system_id))
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
+    echo_properties(omnilogic.backyard)
 
 
 def _print_backyard_info(backyardconfig: MSPBackyard, telemetry: TelemetryType | None) -> None:

--- a/pyomnilogic_local/cli/get/backyard.py
+++ b/pyomnilogic_local/cli/get/backyard.py
@@ -12,8 +12,8 @@ from pyomnilogic_local.omnitypes import BackyardState
 
 if TYPE_CHECKING:
     from pyomnilogic_local import OmniLogic
-    from pyomnilogic_local.models.mspconfig import MSPBackyard, MSPConfig
-    from pyomnilogic_local.models.telemetry import Telemetry, TelemetryType
+    from pyomnilogic_local.models.mspconfig import MSPBackyard
+    from pyomnilogic_local.models.telemetry import TelemetryType
 
 
 @click.command()

--- a/pyomnilogic_local/cli/get/bows.py
+++ b/pyomnilogic_local/cli/get/bows.py
@@ -7,9 +7,11 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from pyomnilogic_local.cli.utils import echo_properties
 from pyomnilogic_local.omnitypes import BodyOfWaterType
 
 if TYPE_CHECKING:
+    from pyomnilogic_local import OmniLogic
     from pyomnilogic_local.models.mspconfig import MSPBoW, MSPConfig
     from pyomnilogic_local.models.telemetry import Telemetry, TelemetryType
 
@@ -25,18 +27,12 @@ def bows(ctx: click.Context) -> None:
     Example:
         omnilogic get bows
     """
-    mspconfig: MSPConfig = ctx.obj["MSPCONFIG"]
-    telemetry: Telemetry = ctx.obj["TELEMETRY"]
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
+    all_bows = omnilogic.all_bows
+    for bow in all_bows:
+        echo_properties(bow)
 
-    bows_found = False
-
-    # Check for BOWs in the backyard
-    if mspconfig.backyard.bow:
-        for bow in mspconfig.backyard.bow:
-            bows_found = True
-            _print_bow_info(bow, telemetry.get_telem_by_systemid(bow.system_id))
-
-    if not bows_found:
+    if len(all_bows) == 0:
         click.echo("No Bodies of Water found in the system configuration.")
 
 

--- a/pyomnilogic_local/cli/get/bows.py
+++ b/pyomnilogic_local/cli/get/bows.py
@@ -12,8 +12,8 @@ from pyomnilogic_local.omnitypes import BodyOfWaterType
 
 if TYPE_CHECKING:
     from pyomnilogic_local import OmniLogic
-    from pyomnilogic_local.models.mspconfig import MSPBoW, MSPConfig
-    from pyomnilogic_local.models.telemetry import Telemetry, TelemetryType
+    from pyomnilogic_local.models.mspconfig import MSPBoW
+    from pyomnilogic_local.models.telemetry import TelemetryType
 
 
 @click.command()

--- a/pyomnilogic_local/cli/get/chlorinators.py
+++ b/pyomnilogic_local/cli/get/chlorinators.py
@@ -3,15 +3,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
 
 import click
 
-from pyomnilogic_local.omnitypes import ChlorinatorCellType, ChlorinatorDispenserType, ChlorinatorOperatingMode
+from pyomnilogic_local.cli.utils import echo_properties
 
 if TYPE_CHECKING:
-    from pyomnilogic_local.models.mspconfig import MSPChlorinator, MSPConfig
-    from pyomnilogic_local.models.telemetry import Telemetry, TelemetryChlorinator
+    from pyomnilogic_local import OmniLogic
 
 
 @click.command()
@@ -25,51 +24,11 @@ def chlorinators(ctx: click.Context) -> None:
     Example:
         omnilogic get chlorinators
     """
-    mspconfig: MSPConfig = ctx.obj["MSPCONFIG"]
-    telemetry: Telemetry = ctx.obj["TELEMETRY"]
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
 
-    chlorinators_found = False
+    chlorinators = omnilogic.all_chlorinators
+    for chlor in chlorinators:
+        echo_properties(chlor)
 
-    # Check for chlorinators in Bodies of Water
-    if mspconfig.backyard.bow:
-        for bow in mspconfig.backyard.bow:
-            if bow.chlorinator:
-                chlorinators_found = True
-                _print_chlorinator_info(
-                    bow.chlorinator, cast("TelemetryChlorinator", telemetry.get_telem_by_systemid(bow.chlorinator.system_id))
-                )
-
-    if not chlorinators_found:
+    if len(chlorinators) == 0:
         click.echo("No chlorinators found in the system configuration.")
-
-
-def _print_chlorinator_info(chlorinator: MSPChlorinator, telemetry: TelemetryChlorinator | None) -> None:
-    """Format and print chlorinator information in a nice table format.
-
-    Args:
-        chlorinator: Chlorinator object from MSPConfig with attributes to display
-        telemetry: Telemetry object containing current state information
-    """
-    click.echo("\n" + "=" * 60)
-    click.echo("CHLORINATOR")
-    click.echo("=" * 60)
-
-    chlor_data: dict[Any, Any] = {**dict(chlorinator), **dict(telemetry)} if telemetry else dict(chlorinator)
-    for attr_name, value in chlor_data.items():
-        if attr_name == "cell_type":
-            value = ChlorinatorCellType(value).pretty()
-        elif attr_name == "dispenser_type":
-            value = ChlorinatorDispenserType(value).pretty()
-        elif attr_name == "operating_mode":
-            value = ChlorinatorOperatingMode(value).pretty()
-        elif attr_name in ("status", "alerts", "errors") and isinstance(value, list):
-            # These are computed properties that return lists of flag names
-            value = ", ".join(value) if value else "None"
-        elif isinstance(value, list):
-            # Format other lists nicely
-            value = ", ".join(str(v) for v in value) if value else "None"
-
-        # Format the attribute name to be more readable
-        display_name = attr_name.replace("_", " ").title()
-        click.echo(f"{display_name:20} : {value}")
-    click.echo("=" * 60)

--- a/pyomnilogic_local/cli/get/commands.py
+++ b/pyomnilogic_local/cli/get/commands.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import click
 
-from pyomnilogic_local.cli import ensure_connection
 from pyomnilogic_local.cli.get.backyard import backyard
 from pyomnilogic_local.cli.get.bows import bows
 from pyomnilogic_local.cli.get.chlorinators import chlorinators
@@ -30,8 +29,6 @@ def get(ctx: click.Context) -> None:
     such as lights, filters, heaters, and other devices.
     """
     ctx.ensure_object(dict)
-    # Ensure we're connected to the controller before running any get commands
-    ensure_connection(ctx)
 
 
 # Register subcommands

--- a/pyomnilogic_local/cli/get/csads.py
+++ b/pyomnilogic_local/cli/get/csads.py
@@ -7,9 +7,11 @@ from typing import TYPE_CHECKING, Any, cast
 
 import click
 
+from pyomnilogic_local.cli.utils import echo_properties
 from pyomnilogic_local.omnitypes import CSADMode, CSADType
 
 if TYPE_CHECKING:
+    from pyomnilogic_local import OmniLogic
     from pyomnilogic_local.models.mspconfig import MSPCSAD, MSPConfig
     from pyomnilogic_local.models.telemetry import Telemetry, TelemetryCSAD
 
@@ -25,20 +27,12 @@ def csads(ctx: click.Context) -> None:
     Example:
         omnilogic get csads
     """
-    mspconfig: MSPConfig = ctx.obj["MSPCONFIG"]
-    telemetry: Telemetry = ctx.obj["TELEMETRY"]
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
+    all_csads = omnilogic.all_csads
+    for csad in all_csads:
+        echo_properties(csad)
 
-    csads_found = False
-
-    # Check for CSADs in Bodies of Water
-    if mspconfig.backyard.bow:
-        for bow in mspconfig.backyard.bow:
-            if bow.csad:
-                for csad in bow.csad:
-                    csads_found = True
-                    _print_csad_info(csad, cast("TelemetryCSAD", telemetry.get_telem_by_systemid(csad.system_id)))
-
-    if not csads_found:
+    if len(all_csads) == 0:
         click.echo("No CSAD systems found in the system configuration.")
 
 

--- a/pyomnilogic_local/cli/get/csads.py
+++ b/pyomnilogic_local/cli/get/csads.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -12,8 +12,8 @@ from pyomnilogic_local.omnitypes import CSADMode, CSADType
 
 if TYPE_CHECKING:
     from pyomnilogic_local import OmniLogic
-    from pyomnilogic_local.models.mspconfig import MSPCSAD, MSPConfig
-    from pyomnilogic_local.models.telemetry import Telemetry, TelemetryCSAD
+    from pyomnilogic_local.models.mspconfig import MSPCSAD
+    from pyomnilogic_local.models.telemetry import TelemetryCSAD
 
 
 @click.command()

--- a/pyomnilogic_local/cli/get/filters.py
+++ b/pyomnilogic_local/cli/get/filters.py
@@ -7,9 +7,11 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from pyomnilogic_local.cli.utils import echo_properties
 from pyomnilogic_local.omnitypes import FilterState, FilterType, FilterValvePosition, FilterWhyOn
 
 if TYPE_CHECKING:
+    from pyomnilogic_local import OmniLogic
     from pyomnilogic_local.models.mspconfig import MSPConfig, MSPFilter
     from pyomnilogic_local.models.telemetry import Telemetry, TelemetryType
 
@@ -25,20 +27,12 @@ def filters(ctx: click.Context) -> None:
     Example:
         omnilogic get filters
     """
-    mspconfig: MSPConfig = ctx.obj["MSPCONFIG"]
-    telemetry: Telemetry = ctx.obj["TELEMETRY"]
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
+    all_filters = omnilogic.all_filters
+    for filt in all_filters:
+        echo_properties(filt)
 
-    filters_found = False
-
-    # Check for filters in Bodies of Water
-    if mspconfig.backyard.bow:
-        for bow in mspconfig.backyard.bow:
-            if bow.filter:
-                for filt in bow.filter:
-                    filters_found = True
-                    _print_filter_info(filt, telemetry.get_telem_by_systemid(filt.system_id))
-
-    if not filters_found:
+    if len(all_filters) == 0:
         click.echo("No filters found in the system configuration.")
 
 

--- a/pyomnilogic_local/cli/get/filters.py
+++ b/pyomnilogic_local/cli/get/filters.py
@@ -12,8 +12,8 @@ from pyomnilogic_local.omnitypes import FilterState, FilterType, FilterValvePosi
 
 if TYPE_CHECKING:
     from pyomnilogic_local import OmniLogic
-    from pyomnilogic_local.models.mspconfig import MSPConfig, MSPFilter
-    from pyomnilogic_local.models.telemetry import Telemetry, TelemetryType
+    from pyomnilogic_local.models.mspconfig import MSPFilter
+    from pyomnilogic_local.models.telemetry import TelemetryType
 
 
 @click.command()

--- a/pyomnilogic_local/cli/get/groups.py
+++ b/pyomnilogic_local/cli/get/groups.py
@@ -7,9 +7,11 @@ from typing import TYPE_CHECKING, Any, cast
 
 import click
 
+from pyomnilogic_local.cli.utils import echo_properties
 from pyomnilogic_local.omnitypes import GroupState
 
 if TYPE_CHECKING:
+    from pyomnilogic_local import OmniLogic
     from pyomnilogic_local.models.mspconfig import MSPConfig, MSPGroup
     from pyomnilogic_local.models.telemetry import Telemetry, TelemetryGroup
 
@@ -25,18 +27,12 @@ def groups(ctx: click.Context) -> None:
     Example:
         omnilogic get groups
     """
-    mspconfig: MSPConfig = ctx.obj["MSPCONFIG"]
-    telemetry: Telemetry = ctx.obj["TELEMETRY"]
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
+    all_groups = omnilogic.groups
+    for group in all_groups:
+        echo_properties(group)
 
-    groups_found = False
-
-    # Check for groups at the top level
-    if mspconfig.groups:
-        for group in mspconfig.groups:
-            groups_found = True
-            _print_group_info(group, cast("TelemetryGroup", telemetry.get_telem_by_systemid(group.system_id)))
-
-    if not groups_found:
+    if len(all_groups) == 0:
         click.echo("No groups found in the system configuration.")
 
 

--- a/pyomnilogic_local/cli/get/groups.py
+++ b/pyomnilogic_local/cli/get/groups.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -12,8 +12,8 @@ from pyomnilogic_local.omnitypes import GroupState
 
 if TYPE_CHECKING:
     from pyomnilogic_local import OmniLogic
-    from pyomnilogic_local.models.mspconfig import MSPConfig, MSPGroup
-    from pyomnilogic_local.models.telemetry import Telemetry, TelemetryGroup
+    from pyomnilogic_local.models.mspconfig import MSPGroup
+    from pyomnilogic_local.models.telemetry import TelemetryGroup
 
 
 @click.command()

--- a/pyomnilogic_local/cli/get/heaters.py
+++ b/pyomnilogic_local/cli/get/heaters.py
@@ -7,10 +7,12 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from pyomnilogic_local.cli.utils import echo_properties
 from pyomnilogic_local.omnitypes import HeaterMode, HeaterState, HeaterType
 
 if TYPE_CHECKING:
-    from pyomnilogic_local.models.mspconfig import MSPConfig, MSPHeaterEquip, MSPVirtualHeater
+    from pyomnilogic_local import OmniLogic
+    from pyomnilogic_local.models.mspconfig import MSPHeaterEquip, MSPVirtualHeater
     from pyomnilogic_local.models.telemetry import Telemetry
 
 
@@ -29,19 +31,17 @@ def heaters(ctx: click.Context) -> None:
     Example:
         omnilogic get heaters
     """
-    mspconfig: MSPConfig = ctx.obj["MSPCONFIG"]
-    telemetry: Telemetry = ctx.obj["TELEMETRY"]
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
 
-    heaters_found = False
+    all_heaters = omnilogic.all_heaters
+    for heater in all_heaters:
+        echo_properties(heater)
 
-    # Check for heaters in Bodies of Water
-    if mspconfig.backyard.bow:
-        for bow in mspconfig.backyard.bow:
-            if bow.heater:
-                heaters_found = True
-                _print_virtual_heater_info(bow.heater, telemetry)
+    all_heater_equipment = omnilogic.all_heater_equipment
+    for heater_equip in all_heater_equipment:
+        echo_properties(heater_equip)
 
-    if not heaters_found:
+    if len(all_heaters) == 0:
         click.echo("No heaters found in the system configuration.")
 
 

--- a/pyomnilogic_local/cli/get/lights.py
+++ b/pyomnilogic_local/cli/get/lights.py
@@ -7,9 +7,11 @@ from typing import TYPE_CHECKING, Any, cast
 
 import click
 
+from pyomnilogic_local.cli.utils import echo_properties
 from pyomnilogic_local.omnitypes import ColorLogicBrightness, ColorLogicPowerState, ColorLogicSpeed
 
 if TYPE_CHECKING:
+    from pyomnilogic_local import OmniLogic
     from pyomnilogic_local.models.mspconfig import MSPColorLogicLight, MSPConfig
     from pyomnilogic_local.models.telemetry import Telemetry, TelemetryColorLogicLight
 
@@ -25,26 +27,12 @@ def lights(ctx: click.Context) -> None:
     Example:
         omnilogic get lights
     """
-    mspconfig: MSPConfig = ctx.obj["MSPCONFIG"]
-    telemetry: Telemetry = ctx.obj["TELEMETRY"]
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
+    all_lights = omnilogic.all_lights
+    for light in all_lights:
+        echo_properties(light)
 
-    lights_found = False
-
-    # Check for lights in the backyard
-    if mspconfig.backyard.colorlogic_light:
-        for light in mspconfig.backyard.colorlogic_light:
-            lights_found = True
-            _print_light_info(light, cast("TelemetryColorLogicLight", telemetry.get_telem_by_systemid(light.system_id)))
-
-    # Check for lights in Bodies of Water
-    if mspconfig.backyard.bow:
-        for bow in mspconfig.backyard.bow:
-            if bow.colorlogic_light:
-                for cl_light in bow.colorlogic_light:
-                    lights_found = True
-                    _print_light_info(cl_light, cast("TelemetryColorLogicLight", telemetry.get_telem_by_systemid(cl_light.system_id)))
-
-    if not lights_found:
+    if len(all_lights) == 0:
         click.echo("No ColorLogic lights found in the system configuration.")
 
 

--- a/pyomnilogic_local/cli/get/lights.py
+++ b/pyomnilogic_local/cli/get/lights.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -12,8 +12,8 @@ from pyomnilogic_local.omnitypes import ColorLogicBrightness, ColorLogicPowerSta
 
 if TYPE_CHECKING:
     from pyomnilogic_local import OmniLogic
-    from pyomnilogic_local.models.mspconfig import MSPColorLogicLight, MSPConfig
-    from pyomnilogic_local.models.telemetry import Telemetry, TelemetryColorLogicLight
+    from pyomnilogic_local.models.mspconfig import MSPColorLogicLight
+    from pyomnilogic_local.models.telemetry import TelemetryColorLogicLight
 
 
 @click.command()

--- a/pyomnilogic_local/cli/get/pumps.py
+++ b/pyomnilogic_local/cli/get/pumps.py
@@ -7,9 +7,11 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from pyomnilogic_local.cli.utils import echo_properties
 from pyomnilogic_local.omnitypes import PumpFunction, PumpState, PumpType
 
 if TYPE_CHECKING:
+    from pyomnilogic_local import OmniLogic
     from pyomnilogic_local.models.mspconfig import MSPConfig, MSPPump
     from pyomnilogic_local.models.telemetry import Telemetry, TelemetryType
 
@@ -25,20 +27,12 @@ def pumps(ctx: click.Context) -> None:
     Example:
         omnilogic get pumps
     """
-    mspconfig: MSPConfig = ctx.obj["MSPCONFIG"]
-    telemetry: Telemetry = ctx.obj["TELEMETRY"]
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
+    all_pumps = omnilogic.all_pumps
+    for pump in all_pumps:
+        echo_properties(pump)
 
-    pumps_found = False
-
-    # Check for pumps in Bodies of Water
-    if mspconfig.backyard.bow:
-        for bow in mspconfig.backyard.bow:
-            if bow.pump:
-                for pump in bow.pump:
-                    pumps_found = True
-                    _print_pump_info(pump, telemetry.get_telem_by_systemid(pump.system_id))
-
-    if not pumps_found:
+    if len(all_pumps) == 0:
         click.echo("No pumps found in the system configuration.")
 
 

--- a/pyomnilogic_local/cli/get/pumps.py
+++ b/pyomnilogic_local/cli/get/pumps.py
@@ -12,8 +12,8 @@ from pyomnilogic_local.omnitypes import PumpFunction, PumpState, PumpType
 
 if TYPE_CHECKING:
     from pyomnilogic_local import OmniLogic
-    from pyomnilogic_local.models.mspconfig import MSPConfig, MSPPump
-    from pyomnilogic_local.models.telemetry import Telemetry, TelemetryType
+    from pyomnilogic_local.models.mspconfig import MSPPump
+    from pyomnilogic_local.models.telemetry import TelemetryType
 
 
 @click.command()

--- a/pyomnilogic_local/cli/get/relays.py
+++ b/pyomnilogic_local/cli/get/relays.py
@@ -12,8 +12,8 @@ from pyomnilogic_local.omnitypes import RelayFunction, RelayState, RelayType, Re
 
 if TYPE_CHECKING:
     from pyomnilogic_local import OmniLogic
-    from pyomnilogic_local.models.mspconfig import MSPConfig, MSPRelay
-    from pyomnilogic_local.models.telemetry import Telemetry, TelemetryType
+    from pyomnilogic_local.models.mspconfig import MSPRelay
+    from pyomnilogic_local.models.telemetry import TelemetryType
 
 
 @click.command()

--- a/pyomnilogic_local/cli/get/relays.py
+++ b/pyomnilogic_local/cli/get/relays.py
@@ -7,9 +7,11 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from pyomnilogic_local.cli.utils import echo_properties
 from pyomnilogic_local.omnitypes import RelayFunction, RelayState, RelayType, RelayWhyOn
 
 if TYPE_CHECKING:
+    from pyomnilogic_local import OmniLogic
     from pyomnilogic_local.models.mspconfig import MSPConfig, MSPRelay
     from pyomnilogic_local.models.telemetry import Telemetry, TelemetryType
 
@@ -25,26 +27,12 @@ def relays(ctx: click.Context) -> None:
     Example:
         omnilogic get relays
     """
-    mspconfig: MSPConfig = ctx.obj["MSPCONFIG"]
-    telemetry: Telemetry = ctx.obj["TELEMETRY"]
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
+    all_relays = omnilogic.all_relays
+    for relay in all_relays:
+        echo_properties(relay)
 
-    relays_found = False
-
-    # Check for relays in the backyard
-    if mspconfig.backyard.relay:
-        for relay in mspconfig.backyard.relay:
-            relays_found = True
-            _print_relay_info(relay, telemetry.get_telem_by_systemid(relay.system_id))
-
-    # Check for relays in Bodies of Water
-    if mspconfig.backyard.bow:
-        for bow in mspconfig.backyard.bow:
-            if bow.relay:
-                for relay in bow.relay:
-                    relays_found = True
-                    _print_relay_info(relay, telemetry.get_telem_by_systemid(relay.system_id))
-
-    if not relays_found:
+    if len(all_relays) == 0:
         click.echo("No relays found in the system configuration.")
 
 

--- a/pyomnilogic_local/cli/get/schedules.py
+++ b/pyomnilogic_local/cli/get/schedules.py
@@ -11,7 +11,7 @@ from pyomnilogic_local.cli.utils import echo_properties
 
 if TYPE_CHECKING:
     from pyomnilogic_local import OmniLogic
-    from pyomnilogic_local.models.mspconfig import MSPConfig, MSPSchedule
+    from pyomnilogic_local.models.mspconfig import MSPSchedule
 
 
 @click.command()

--- a/pyomnilogic_local/cli/get/schedules.py
+++ b/pyomnilogic_local/cli/get/schedules.py
@@ -7,7 +7,10 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from pyomnilogic_local.cli.utils import echo_properties
+
 if TYPE_CHECKING:
+    from pyomnilogic_local import OmniLogic
     from pyomnilogic_local.models.mspconfig import MSPConfig, MSPSchedule
 
 
@@ -22,17 +25,12 @@ def schedules(ctx: click.Context) -> None:
     Example:
         omnilogic get schedules
     """
-    mspconfig: MSPConfig = ctx.obj["MSPCONFIG"]
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
+    all_schedules = omnilogic.schedules
+    for schedule in all_schedules:
+        echo_properties(schedule)
 
-    schedules_found = False
-
-    # Check for schedules at the top level
-    if mspconfig.schedules:
-        for schedule in mspconfig.schedules:
-            schedules_found = True
-            _print_schedule_info(schedule)
-
-    if not schedules_found:
+    if len(all_schedules) == 0:
         click.echo("No schedules found in the system configuration.")
 
 

--- a/pyomnilogic_local/cli/get/sensors.py
+++ b/pyomnilogic_local/cli/get/sensors.py
@@ -7,9 +7,11 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from pyomnilogic_local.cli.utils import echo_properties
 from pyomnilogic_local.omnitypes import SensorType, SensorUnits
 
 if TYPE_CHECKING:
+    from pyomnilogic_local import OmniLogic
     from pyomnilogic_local.models.mspconfig import MSPConfig, MSPSensor
 
 
@@ -24,25 +26,12 @@ def sensors(ctx: click.Context) -> None:
     Example:
         omnilogic get sensors
     """
-    mspconfig: MSPConfig = ctx.obj["MSPCONFIG"]
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
+    all_sensors = omnilogic.all_sensors
+    for sensor in all_sensors:
+        echo_properties(sensor)
 
-    sensors_found = False
-
-    # Check for sensors in the backyard
-    if mspconfig.backyard.sensor:
-        for sensor in mspconfig.backyard.sensor:
-            sensors_found = True
-            _print_sensor_info(sensor)
-
-    # Check for sensors in Bodies of Water
-    if mspconfig.backyard.bow:
-        for bow in mspconfig.backyard.bow:
-            if bow.sensor:
-                for sensor in bow.sensor:
-                    sensors_found = True
-                    _print_sensor_info(sensor)
-
-    if not sensors_found:
+    if len(all_sensors) == 0:
         click.echo("No sensors found in the system configuration.")
 
 

--- a/pyomnilogic_local/cli/get/sensors.py
+++ b/pyomnilogic_local/cli/get/sensors.py
@@ -12,7 +12,7 @@ from pyomnilogic_local.omnitypes import SensorType, SensorUnits
 
 if TYPE_CHECKING:
     from pyomnilogic_local import OmniLogic
-    from pyomnilogic_local.models.mspconfig import MSPConfig, MSPSensor
+    from pyomnilogic_local.models.mspconfig import MSPSensor
 
 
 @click.command()

--- a/pyomnilogic_local/cli/get/valves.py
+++ b/pyomnilogic_local/cli/get/valves.py
@@ -7,9 +7,11 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from pyomnilogic_local.cli.utils import echo_properties
 from pyomnilogic_local.omnitypes import RelayFunction, RelayType, RelayWhyOn, ValveActuatorState
 
 if TYPE_CHECKING:
+    from pyomnilogic_local import OmniLogic
     from pyomnilogic_local.models.mspconfig import MSPConfig, MSPRelay
     from pyomnilogic_local.models.telemetry import Telemetry
 
@@ -30,28 +32,12 @@ def valves(ctx: click.Context) -> None:
     Example:
         omnilogic get valves
     """
-    mspconfig: MSPConfig = ctx.obj["MSPCONFIG"]
-    telemetry: Telemetry = ctx.obj["TELEMETRY"]
+    omnilogic: OmniLogic = ctx.obj["OMNILOGIC"]
+    valve_relays = [relay for relay in omnilogic.all_relays if relay.relay_type == RelayType.VALVE_ACTUATOR]
+    for valve in valve_relays:
+        echo_properties(valve)
 
-    valves_found = False
-
-    # Check for valve actuators in the backyard
-    if mspconfig.backyard.relay:
-        for relay in mspconfig.backyard.relay:
-            if relay.type == RelayType.VALVE_ACTUATOR:
-                valves_found = True
-                _print_valve_info(relay, telemetry)
-
-    # Check for valve actuators in Bodies of Water
-    if mspconfig.backyard.bow:
-        for bow in mspconfig.backyard.bow:
-            if bow.relay:
-                for relay in bow.relay:
-                    if relay.type == RelayType.VALVE_ACTUATOR:
-                        valves_found = True
-                        _print_valve_info(relay, telemetry)
-
-    if not valves_found:
+    if len(valve_relays) == 0:
         click.echo("No valve actuators found in the system configuration.")
 
 

--- a/pyomnilogic_local/cli/get/valves.py
+++ b/pyomnilogic_local/cli/get/valves.py
@@ -12,7 +12,7 @@ from pyomnilogic_local.omnitypes import RelayFunction, RelayType, RelayWhyOn, Va
 
 if TYPE_CHECKING:
     from pyomnilogic_local import OmniLogic
-    from pyomnilogic_local.models.mspconfig import MSPConfig, MSPRelay
+    from pyomnilogic_local.models.mspconfig import MSPRelay
     from pyomnilogic_local.models.telemetry import Telemetry
 
 

--- a/pyomnilogic_local/cli/utils.py
+++ b/pyomnilogic_local/cli/utils.py
@@ -8,14 +8,12 @@ from __future__ import annotations
 
 import inspect
 import os
-from typing import TYPE_CHECKING, Literal, overload
+from typing import Any
 
 import click
 
 from pyomnilogic_local.api.api import OmniLogicAPI
-
-if TYPE_CHECKING:
-    from pyomnilogic_local.models.filter_diagnostics import FilterDiagnostics
+from pyomnilogic_local.api.mock_api import OmniLogicMockAPI
 
 
 async def get_omni(host: str) -> OmniLogicAPI:
@@ -29,32 +27,11 @@ async def get_omni(host: str) -> OmniLogicAPI:
     """
     sim_data_path = os.environ.get("PYOMNILOGIC_SIMULATION_DATA")
     if sim_data_path:
-        from pyomnilogic_local.api.mock_api import OmniLogicMockAPI
-
         return OmniLogicMockAPI(sim_data_path)  # type: ignore[return-value]
     return OmniLogicAPI(host, 10444, 5.0)
 
 
-@overload
-async def async_get_filter_diagnostics(omni: OmniLogicAPI, pool_id: int, filter_id: int, raw: Literal[True]) -> str: ...
-@overload
-async def async_get_filter_diagnostics(omni: OmniLogicAPI, pool_id: int, filter_id: int, raw: Literal[False]) -> FilterDiagnostics: ...
-async def async_get_filter_diagnostics(omni: OmniLogicAPI, pool_id: int, filter_id: int, raw: bool) -> FilterDiagnostics | str:
-    """Retrieve filter diagnostics from the controller.
-
-    Args:
-        omni: OmniLogicAPI instance for controller communication
-        pool_id: System ID of the Body Of Water
-        filter_id: System ID of the filter/pump
-        raw: If True, return raw XML string; if False, return parsed FilterDiagnostics object
-
-    Returns:
-        FilterDiagnostics object or raw XML string depending on raw parameter
-    """
-    return await omni.async_get_filter_diagnostics(pool_id, filter_id, raw=raw)
-
-
-def echo_properties(obj):
+def echo_properties(obj: Any) -> None:
     """Echo all properties of an object in a formatted way."""
     # 1. Identify the properties from the class
     prop_names = [name for name, value in inspect.getmembers(type(obj), lambda x: isinstance(x, property))]

--- a/pyomnilogic_local/cli/utils.py
+++ b/pyomnilogic_local/cli/utils.py
@@ -6,7 +6,8 @@ accessing controller data within the Click context.
 
 from __future__ import annotations
 
-import asyncio
+import inspect
+import os
 from typing import TYPE_CHECKING, Literal, overload
 
 import click
@@ -15,8 +16,6 @@ from pyomnilogic_local.api.api import OmniLogicAPI
 
 if TYPE_CHECKING:
     from pyomnilogic_local.models.filter_diagnostics import FilterDiagnostics
-    from pyomnilogic_local.models.mspconfig import MSPConfig
-    from pyomnilogic_local.models.telemetry import Telemetry
 
 
 async def get_omni(host: str) -> OmniLogicAPI:
@@ -28,69 +27,18 @@ async def get_omni(host: str) -> OmniLogicAPI:
     Returns:
         Configured OmniLogicAPI instance ready for communication
     """
+    sim_data_path = os.environ.get("PYOMNILOGIC_SIMULATION_DATA")
+    if sim_data_path:
+        from pyomnilogic_local.api.mock_api import OmniLogicMockAPI
+
+        return OmniLogicMockAPI(sim_data_path)  # type: ignore[return-value]
     return OmniLogicAPI(host, 10444, 5.0)
-
-
-async def fetch_startup_data(omni: OmniLogicAPI) -> tuple[MSPConfig, Telemetry]:
-    """Fetch MSPConfig and Telemetry from the controller.
-
-    Args:
-        omni: OmniLogicAPI instance for controller communication
-
-    Returns:
-        Tuple of (mspconfig, telemetry) data objects
-
-    Raises:
-        RuntimeError: If unable to fetch configuration or telemetry from controller
-    """
-    try:
-        mspconfig = await omni.async_get_mspconfig()
-        telemetry = await omni.async_get_telemetry()
-    except Exception as exc:
-        msg = f"[ERROR] Failed to fetch config or telemetry from controller: {exc}"
-        raise RuntimeError(msg) from exc
-    return mspconfig, telemetry
-
-
-def ensure_connection(ctx: click.Context) -> None:
-    """Ensure the controller connection is established and data is cached.
-
-    This function should be called by subcommands that need to access the controller.
-    It will only connect once, caching the connection and data in the context.
-
-    Args:
-        ctx: Click context object
-
-    Raises:
-        SystemExit: If connection to controller fails
-    """
-    # If already connected, return early
-    if "OMNI" in ctx.obj:
-        return
-
-    # Get the host from context (stored by entrypoint)
-    host = ctx.obj.get("HOST", "127.0.0.1")
-
-    try:
-        omni = asyncio.run(get_omni(host))
-        mspconfig, telemetry = asyncio.run(fetch_startup_data(omni))
-    except Exception as exc:
-        click.secho(str(exc), fg="red", err=True)
-        ctx.exit(1)
-
-    ctx.obj["OMNI"] = omni
-    ctx.obj["MSPCONFIG"] = mspconfig
-    ctx.obj["TELEMETRY"] = telemetry
 
 
 @overload
 async def async_get_filter_diagnostics(omni: OmniLogicAPI, pool_id: int, filter_id: int, raw: Literal[True]) -> str: ...
-
-
 @overload
 async def async_get_filter_diagnostics(omni: OmniLogicAPI, pool_id: int, filter_id: int, raw: Literal[False]) -> FilterDiagnostics: ...
-
-
 async def async_get_filter_diagnostics(omni: OmniLogicAPI, pool_id: int, filter_id: int, raw: bool) -> FilterDiagnostics | str:
     """Retrieve filter diagnostics from the controller.
 
@@ -104,3 +52,32 @@ async def async_get_filter_diagnostics(omni: OmniLogicAPI, pool_id: int, filter_
         FilterDiagnostics object or raw XML string depending on raw parameter
     """
     return await omni.async_get_filter_diagnostics(pool_id, filter_id, raw=raw)
+
+
+def echo_properties(obj):
+    """Echo all properties of an object in a formatted way."""
+    # 1. Identify the properties from the class
+    prop_names = [name for name, value in inspect.getmembers(type(obj), lambda x: isinstance(x, property))]
+    longest_name = max(prop_names, key=len, default="")
+    name_length = len(click.style(longest_name, fg="green"))  # Get the length including the ANSI color codes
+    name_column_width = name_length + 2  # Add some padding
+
+    if not prop_names:
+        click.echo(click.style("No properties found.", fg="yellow"))
+        return
+
+    click.echo("\n" + "=" * 60)
+    click.echo(click.style(f"Instance of {type(obj).__name__}:", fg="cyan", bold=True))
+    click.echo("=" * 60)
+
+    # 2. Iterate and echo with formatting
+    for name in sorted(prop_names):
+        if name in ("_api"):  # Skip internal properties that are not relevant to display
+            continue
+        try:
+            value = getattr(obj, name)
+            # Label in green, value in default/white
+            click.echo(f"  {click.style(name, fg='green'):{name_column_width}}: {value}")
+        except Exception as e:
+            # Handle cases where the property might fail
+            click.echo(f"  {click.style(name, fg='red')}: Error ({e})")

--- a/pyomnilogic_local/csad.py
+++ b/pyomnilogic_local/csad.py
@@ -303,26 +303,3 @@ class CSAD(OmniEquipment[MSPCSAD, TelemetryCSAD]):
             ...     print(f"pH is {offset:.2f} points above target")
         """
         return self.current_ph - self.target_ph
-
-    @property
-    def is_ready(self) -> bool:
-        """Check if the CSAD is ready to accept commands.
-
-        A CSAD is considered ready if:
-        - The backyard is not in service/config mode (checked by parent class)
-        - It is enabled and in a stable operating mode (AUTO, MONITORING, or FORCE_ON)
-        - Not in a transitional or error state
-
-        Returns:
-            True if CSAD can accept commands, False otherwise
-
-        Example:
-            >>> if csad.is_ready:
-            ...     await csad.set_mode(CSADMode.AUTO)
-        """
-        # First check if backyard is ready
-        if not super().is_ready:
-            return False
-
-        # Then check CSAD-specific readiness
-        return self.is_on and self.mode in (CSADMode.AUTO, CSADMode.MONITORING, CSADMode.FORCE_ON)

--- a/pyomnilogic_local/filter.py
+++ b/pyomnilogic_local/filter.py
@@ -193,7 +193,7 @@ class Filter(OmniEquipment[MSPFilter, TelemetryFilter]):
         if not super().is_ready:
             return False
 
-        # Then check filter-specific readiness
+        # Then check filter-specific readiness to make sure it's in a state that can accept commands
         return self.state in (FilterState.OFF, FilterState.ON)
 
     # Control methods

--- a/pyomnilogic_local/omnilogic.py
+++ b/pyomnilogic_local/omnilogic.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -56,7 +57,13 @@ class OmniLogic:
         self.host = host
         self.port = port
 
-        self._api = OmniLogicAPI(host, port, timeout)
+        sim_data_path = os.environ.get("PYOMNILOGIC_SIMULATION_DATA")
+        if sim_data_path:
+            from pyomnilogic_local.api.mock_api import OmniLogicMockAPI
+
+            self._api = OmniLogicMockAPI(sim_data_path)  # type: ignore[assignment]
+        else:
+            self._api = OmniLogicAPI(host, port, timeout)
         self._refresh_lock = asyncio.Lock()
 
     def __repr__(self) -> str:

--- a/pyomnilogic_local/omnilogic.py
+++ b/pyomnilogic_local/omnilogic.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from pyomnilogic_local.api import OmniLogicAPI
 from pyomnilogic_local.api.constants import DEFAULT_RESPONSE_TIMEOUT
+from pyomnilogic_local.api.mock_api import OmniLogicMockAPI
 from pyomnilogic_local.backyard import Backyard
 from pyomnilogic_local.collections import EquipmentDict
 from pyomnilogic_local.groups import Group
@@ -43,6 +44,7 @@ class OmniLogic:
     groups: EquipmentDict[Group]
     schedules: EquipmentDict[Schedule]
 
+    _api: OmniLogicAPI | OmniLogicMockAPI
     _mspconfig_last_updated: float = 0.0
     _telemetry_last_updated: float = 0.0
     _mspconfig_checksum: int = 0
@@ -59,9 +61,7 @@ class OmniLogic:
 
         sim_data_path = os.environ.get("PYOMNILOGIC_SIMULATION_DATA")
         if sim_data_path:
-            from pyomnilogic_local.api.mock_api import OmniLogicMockAPI
-
-            self._api = OmniLogicMockAPI(sim_data_path)  # type: ignore[assignment]
+            self._api = OmniLogicMockAPI(sim_data_path)
         else:
             self._api = OmniLogicAPI(host, port, timeout)
         self._refresh_lock = asyncio.Lock()

--- a/pyomnilogic_local/pump.py
+++ b/pyomnilogic_local/pump.py
@@ -175,7 +175,7 @@ class Pump(OmniEquipment[MSPPump, TelemetryPump]):
         if not super().is_ready:
             return False
 
-        # Then check pump-specific readiness
+        # Then check pump-specific readiness to make sure it's in a state that can accept commands
         return self.state in (PumpState.OFF, PumpState.ON)
 
     # Control methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,12 @@ build-backend = "uv_build"
 
 [dependency-groups]
 dev = [
-    "pre-commit>=4.0.0,<5.0.0",
     "mypy>=1.18.2,<2.0.0",
     "types-xmltodict >=1.0.1,<2.0.0",
     "pytest>=9.0.0,<10.0.0",
     "pytest-cov>=7.0.0,<8.0.0",
     "pytest-asyncio>=1.2.0,<2.0.0",
+    "prek>=0.3.9",
 ]
 
 [tool.mypy]

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,33 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
+let
+  shellInit = pkgs.writeText "haomnilogic-shell-init" ''
+    # Preserve the user's existing shell configuration
+    if [ -f "$HOME/.bashrc" ]; then
+      source "$HOME/.bashrc"
+    fi
+
+    if [ ! -d ".venv" ]; then
+      echo "--- Initializing venv ---"
+      uv venv --python python3.14
+    fi
+
+    echo "--- Activating Virtual Environment ---"
+    source .venv/bin/activate
+
+    echo "--- Syncing Project Dependencies ---"
+    uv sync --all-extras
+  '';
+in
+(pkgs.buildFHSEnv {
+  name = "haomnilogic-fhs";
+  targetPkgs =
+    pkgs: with pkgs; [
+      python314
+      uv
+    ];
+
+  runScript = "bash --rcfile ${shellInit}";
+}).env

--- a/tests/test_filter_pump.py
+++ b/tests/test_filter_pump.py
@@ -187,7 +187,7 @@ class TestFilter:
         """Test turn_on method calls API correctly."""
         sample_filter_config.bow_id = 7
         filter_obj = Filter(mock_omni, sample_filter_config, mock_telemetry)
-        filter_obj._api.async_set_equipment = AsyncMock()  # type: ignore[method-assign]
+        filter_obj._api.async_set_equipment = AsyncMock()  # type: ignore[method-assign,union-attr]
 
         await filter_obj.turn_on()
 
@@ -202,7 +202,7 @@ class TestFilter:
         """Test turn_off method calls API correctly."""
         sample_filter_config.bow_id = 7
         filter_obj = Filter(mock_omni, sample_filter_config, mock_telemetry)
-        filter_obj._api.async_set_equipment = AsyncMock()  # type: ignore[method-assign]
+        filter_obj._api.async_set_equipment = AsyncMock()  # type: ignore[method-assign,union-attr]
 
         await filter_obj.turn_off()
 
@@ -217,7 +217,7 @@ class TestFilter:
         """Test run_preset_speed with LOW preset."""
         sample_filter_config.bow_id = 7
         filter_obj = Filter(mock_omni, sample_filter_config, mock_telemetry)
-        filter_obj._api.async_set_equipment = AsyncMock()  # type: ignore[method-assign]
+        filter_obj._api.async_set_equipment = AsyncMock()  # type: ignore[method-assign,union-attr]
 
         await filter_obj.run_preset_speed(FilterSpeedPresets.LOW)
 
@@ -232,7 +232,7 @@ class TestFilter:
         """Test run_preset_speed with MEDIUM preset."""
         sample_filter_config.bow_id = 7
         filter_obj = Filter(mock_omni, sample_filter_config, mock_telemetry)
-        filter_obj._api.async_set_equipment = AsyncMock()  # type: ignore[method-assign]
+        filter_obj._api.async_set_equipment = AsyncMock()  # type: ignore[method-assign,union-attr]
 
         await filter_obj.run_preset_speed(FilterSpeedPresets.MEDIUM)
 
@@ -247,7 +247,7 @@ class TestFilter:
         """Test run_preset_speed with HIGH preset."""
         sample_filter_config.bow_id = 7
         filter_obj = Filter(mock_omni, sample_filter_config, mock_telemetry)
-        filter_obj._api.async_set_equipment = AsyncMock()  # type: ignore[method-assign]
+        filter_obj._api.async_set_equipment = AsyncMock()  # type: ignore[method-assign,union-attr]
 
         await filter_obj.run_preset_speed(FilterSpeedPresets.HIGH)
 
@@ -320,7 +320,7 @@ class TestPump:
         """Test turn_on method calls API correctly."""
         sample_pump_config.bow_id = 7
         pump_obj = Pump(mock_omni, sample_pump_config, mock_telemetry)
-        pump_obj._api.async_set_equipment = AsyncMock()  # type: ignore[method-assign]
+        pump_obj._api.async_set_equipment = AsyncMock()  # type: ignore[method-assign,union-attr]
 
         await pump_obj.turn_on()
 
@@ -335,7 +335,7 @@ class TestPump:
         """Test turn_off method calls API correctly."""
         sample_pump_config.bow_id = 7
         pump_obj = Pump(mock_omni, sample_pump_config, mock_telemetry)
-        pump_obj._api.async_set_equipment = AsyncMock()  # type: ignore[method-assign]
+        pump_obj._api.async_set_equipment = AsyncMock()  # type: ignore[method-assign,union-attr]
 
         await pump_obj.turn_off()
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,15 +12,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cfgv"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -78,33 +69,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
     { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
     { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
-]
-
-[[package]]
-name = "distlib"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
-]
-
-[[package]]
-name = "filelock"
-version = "3.25.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
-]
-
-[[package]]
-name = "identify"
-version = "2.6.18"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/46/c4/7fb4db12296cdb11893d61c92048fe617ee853f8523b9b296ac03b43757e/identify-2.6.18.tar.gz", hash = "sha256:873ac56a5e3fd63e7438a7ecbc4d91aca692eb3fefa4534db2b7913f3fc352fd", size = 99580, upload-time = "2026-03-15T18:39:50.319Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/33/92ef41c6fad0233e41d3d84ba8e8ad18d1780f1e5d99b3c683e6d7f98b63/identify-2.6.18-py2.py3-none-any.whl", hash = "sha256:8db9d3c8ea9079db92cafb0ebf97abdc09d52e97f4dcf773a2e694048b7cd737", size = 99394, upload-time = "2026-03-15T18:39:48.915Z" },
 ]
 
 [[package]]
@@ -189,15 +153,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.10.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -216,15 +171,6 @@ wheels = [
 ]
 
 [[package]]
-name = "platformdirs"
-version = "4.9.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
-]
-
-[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -234,19 +180,27 @@ wheels = [
 ]
 
 [[package]]
-name = "pre-commit"
-version = "4.5.1"
+name = "prek"
+version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cfgv" },
-    { name = "identify" },
-    { name = "nodeenv" },
-    { name = "pyyaml" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/ff/5b7a2a9c4fa3dd2ffc8b13a9ec22aa550deda5b39ab273f8e02863b12642/prek-0.3.9.tar.gz", hash = "sha256:f82b92d81f42f1f90a47f5fbbf492373e25ef1f790080215b2722dd6da66510e", size = 423801, upload-time = "2026-04-13T12:30:38.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/08/c11a6b7834b461223763b6b1552f32c9199393685d52d555de621e900ee7/prek-0.3.9-py3-none-linux_armv6l.whl", hash = "sha256:3ed793d51bfaa27bddb64d525d7acb77a7c8644f549412d82252e3eb0b88aad8", size = 5337784, upload-time = "2026-04-13T12:30:46.044Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d9/974b02832a645c6411069c713e3191ce807f9962006da108e4727efd2fa1/prek-0.3.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:399c58400c0bd0b82a93a3c09dc1bfd88d8d0cfb242d414d2ed247187b06ead1", size = 5713864, upload-time = "2026-04-13T12:30:27.007Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e1/4ed14bef15eb30039a75177b0807ac007095a5a110284706ccf900a8d512/prek-0.3.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e2ea1ffb124e92f081b8e2ca5b5a623a733efb3be0c5b1f4b7ffe2ee17d1f20c", size = 5290437, upload-time = "2026-04-13T12:30:30.658Z" },
+    { url = "https://files.pythonhosted.org/packages/67/80/d5c3015e9da161dede566bfeef41f098f92470613157daa4f7377ab08d58/prek-0.3.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:aaf639f95b7301639298311d8d44aad0d0b4864e9736083ad3c71ce9765d37ab", size = 5536208, upload-time = "2026-04-13T12:30:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/54/8cdc5eb1018437d7828740defd322e7a96459c02fc8961160c4120325313/prek-0.3.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ff104863b187fa443ea8451ca55d51e2c6e94f99f00d88784b5c3c4c623f1ebe", size = 5251785, upload-time = "2026-04-13T12:30:39.78Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e2/a5fc35a0fd3167224a000ca1b6235ecbdea0ac77e24af5979a75b0e6b5a4/prek-0.3.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:039ecaf87c63a3e67cca645ebd5bc5eb6aafa6c9d929e9a27b2921e7849d7ef9", size = 5668548, upload-time = "2026-04-13T12:30:24.914Z" },
+    { url = "https://files.pythonhosted.org/packages/09/e8/a189ee79f401c259f66f8af587f899d4d5bfb04e0ca371bfd01e49871007/prek-0.3.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3bde2a3d045705095983c7f78ba04f72a7565fe1c2b4e85f5628502a254754ff", size = 6660927, upload-time = "2026-04-13T12:30:44.495Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5a/54117316e98ff62a14911ad1488a3a0945530242a2ce3e92f7a40b6ccc02/prek-0.3.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28a0960a21543563e2c8e19aaad176cc8423a87aac3c914d0f313030d7a9244a", size = 5932244, upload-time = "2026-04-13T12:30:49.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f9/e88d4361f59be7adeeb3a8a3819d69d286d86fe6f7606840af6734362675/prek-0.3.9-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:0dfb5d5171d7523271909246ee306b4dc3d5b63752e7dd7c7e8a8908fc9490d1", size = 5542139, upload-time = "2026-04-13T12:30:41.266Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1f/204837115087bb8d063bda754a7fe975428c5d5b6548c30dd749f8ab85d4/prek-0.3.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82b791bd36c1430c84d3ae7220a85152babc7eaf00f70adcb961bd594e756ba3", size = 5392519, upload-time = "2026-04-13T12:30:32.603Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/00/de57b5795e670b6d38e7eda6d9ac6fd6d757ca22f725e5054b042104cd53/prek-0.3.9-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:6eac6d2f736b041118f053a1487abed468a70dd85a8688eaf87bb42d3dcecf20", size = 5222780, upload-time = "2026-04-13T12:30:36.576Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/14/0bc055c305d92980b151f2ec00c14d28fe94c6d51180ca07fded28771cbf/prek-0.3.9-py3-none-musllinux_1_1_i686.whl", hash = "sha256:5517e46e761367a3759b3168eabc120840ffbca9dfbc53187167298a98f87dc4", size = 5524310, upload-time = "2026-04-13T12:30:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d1/eebc2b69be0de36cd84adbe0a0710f4deb468a90e30525be027d6db02d54/prek-0.3.9-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:92024778cf78683ca32687bb249ab6a7d5c33887b5ee1d1a9f6d0c14228f4cf3", size = 6043751, upload-time = "2026-04-13T12:30:29.101Z" },
+    { url = "https://files.pythonhosted.org/packages/46/cb/be98c04e702cbc0b0328cd745ff4634ace69ad5a84461bde36f88a7be873/prek-0.3.9-py3-none-win32.whl", hash = "sha256:7f89c55e5f480f5d073769e319924ad69d4bf9f98c5cb46a83082e26e634c958", size = 5045940, upload-time = "2026-04-13T12:30:42.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b6/b51771d69f6282e34edeb73f23d956da34f2cabbb5ba16ba175cc0a056f9/prek-0.3.9-py3-none-win_amd64.whl", hash = "sha256:7722f3372eaa83b147e70a43cb7b9fe2128c13d0c78d8a1cdbf2a8ec2ee071eb", size = 5435204, upload-time = "2026-04-13T12:30:51.482Z" },
+    { url = "https://files.pythonhosted.org/packages/30/8a/f8a87c15b095460eccd67c8d89a086b7a37aac8d363f89544b8ce6ec653d/prek-0.3.9-py3-none-win_arm64.whl", hash = "sha256:0bced6278d6cc8a4b46048979e36bc9da034611dc8facd77ab123177b833a929", size = 5279552, upload-time = "2026-04-13T12:30:53.011Z" },
 ]
 
 [[package]]
@@ -357,19 +311,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-discovery"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "filelock" },
-    { name = "platformdirs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
-]
-
-[[package]]
 name = "python-omnilogic-local"
 version = "0.22.0"
 source = { editable = "." }
@@ -390,7 +331,7 @@ cli = [
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
-    { name = "pre-commit" },
+    { name = "prek" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -410,37 +351,11 @@ provides-extras = ["cli", "build"]
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.18.2,<2.0.0" },
-    { name = "pre-commit", specifier = ">=4.0.0,<5.0.0" },
+    { name = "prek", specifier = ">=0.3.9" },
     { name = "pytest", specifier = ">=9.0.0,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.2.0,<2.0.0" },
     { name = "pytest-cov", specifier = ">=7.0.0,<8.0.0" },
     { name = "types-xmltodict", specifier = ">=1.0.1,<2.0.0" },
-]
-
-[[package]]
-name = "pyyaml"
-version = "6.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
-    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
-    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
-    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
-    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]
@@ -506,21 +421,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/e0/bbd4ba7c2e5067bbba617d87d306ec146889edaeeaa2081d3e122178ca08/uv-0.11.6-py3-none-win32.whl", hash = "sha256:6e8344f38fa29f85dcfd3e62dc35a700d2448f8e90381077ef393438dcd5012e", size = 22865693, upload-time = "2026-04-09T12:09:21.415Z" },
     { url = "https://files.pythonhosted.org/packages/a5/33/1983ce113c538a856f2d620d16e39691962ecceef091a84086c5785e32e5/uv-0.11.6-py3-none-win_amd64.whl", hash = "sha256:a28bea69c1186303d1200f155c7a28c449f8a4431e458fcf89360cc7ef546e40", size = 25371258, upload-time = "2026-04-09T12:09:40.52Z" },
     { url = "https://files.pythonhosted.org/packages/35/01/be0873f44b9c9bc250fcbf263367fcfc1f59feab996355bcb6b52fff080d/uv-0.11.6-py3-none-win_arm64.whl", hash = "sha256:a78f6d64b9950e24061bc7ec7f15ff8089ad7f5a976e7b65fcadce58fe02f613", size = 23869585, upload-time = "2026-04-09T12:09:29.425Z" },
-]
-
-[[package]]
-name = "virtualenv"
-version = "21.2.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "platformdirs" },
-    { name = "python-discovery" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/60/8c/bdd9f89f89e4a787ac61bb2da4d884bc45e0c287ec694dfa3170dddd5cfe/virtualenv-21.2.3.tar.gz", hash = "sha256:9bb6d1414ab55ca624371e30c7719c32f183ef44da544ef8aa44a456de7ac191", size = 5844776, upload-time = "2026-04-14T01:10:36.692Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/19/bc7c4e05f42532863cf2ae7e7e847beab25835934e0410160b47eeff1e35/virtualenv-21.2.3-py3-none-any.whl", hash = "sha256:486652347ea8526d91e9807c0274583cb7ba31dd4942ff10fb5621402f0fe0d8", size = 5828329, upload-time = "2026-04-14T01:10:34.809Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This adds the ability to set the environment variable PYOMNILOGIC_SIMULATION_DATA at a Home Assistant diagnostics dump from the haomnilogic-local integration which bypasses connecting to an OmniLogic and instead uses the MSPConfig and Telemetry from inside the dump.

This is implemented as a mock API layer so it works when running as a library inside Home Assistant as well.

Additionally the CLI has been modified to use the OmniLogic class rather than interacting with the MSPConfig and Telemetry models directly.

This also cleans up some is_ready states for a few devices that were causing issues in the integration.