### PR TITLE
feat: enable mocking from multiple debug files

### DIFF
--- a/pyomnilogic_local/api/mock_api.py
+++ b/pyomnilogic_local/api/mock_api.py
@@ -14,11 +14,17 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class OmniLogicMockAPI:
-    """Drop-in replacement for OmniLogicAPI that serves pre-recorded data from a JSON file.
+    """Drop-in replacement for OmniLogicAPI that serves pre-recorded data from one or more JSON files.
 
-    The JSON file must contain the simulation data at the paths:
+    Each JSON file must contain the simulation data at the paths:
         - ``.data.telemetry``  — raw XML telemetry string
         - ``.data.msp_config`` — raw XML MSP config string
+
+    When multiple files are provided the class maintains a round-robin pointer into the
+    list.  Whether the pointer advances after each call is controlled by two attributes:
+
+    - ``increment_on_mspconfig`` (default ``False``) — advance after ``async_get_mspconfig``
+    - ``increment_on_telemetry`` (default ``True``)  — advance after ``async_get_telemetry``
 
     Any API call other than ``async_get_telemetry`` or ``async_get_mspconfig`` is silently
     absorbed and logged at INFO level; no network traffic is generated.
@@ -28,26 +34,32 @@ class OmniLogicMockAPI:
         """Load simulation data from *filepath*.
 
         Args:
-            filepath: Path to the JSON simulation data file.
+            filepath: Comma-separated path(s) to JSON simulation data file(s).
+                A single path with no commas is treated as a one-element list.
 
         Raises:
-            FileNotFoundError: If the file does not exist at *filepath*.
-            KeyError: If the expected JSON structure is not present in the file.
+            FileNotFoundError: If any file does not exist.
+            KeyError: If the expected JSON structure is not present in a file.
         """
-        path = Path(filepath)
-        if not path.exists():
-            msg = f"Simulation data file not found: {filepath}"
-            raise FileNotFoundError(msg)
+        paths = filepath.split(",")
 
-        data = json.loads(path.read_text(encoding="utf-8"))
-        sim_data: dict[str, Any] = data["data"]
+        self._sim_data: list[dict[str, Any]] = []
+        for fp in paths:
+            path = Path(fp)
+            if not path.exists():
+                msg = f"Simulation data file not found: {fp}"
+                raise FileNotFoundError(msg)
+            data = json.loads(path.read_text(encoding="utf-8"))
+            data["data"]["filepath"] = fp
+            self._sim_data.append(data["data"])
 
-        self._mspconfig = sim_data["msp_config"]
-        self._telemetry = sim_data["telemetry"]
+        self._index = 0
+        self.increment_on_mspconfig = False
+        self.increment_on_telemetry = True
 
         _LOGGER.warning(
-            "Running in simulation mode using data from '%s'. No API calls will be made to the OmniLogic controller.",
-            filepath,
+            "Running in simulation mode using data from %s. No API calls will be made to the OmniLogic controller.",
+            paths,
         )
 
     @overload
@@ -57,10 +69,19 @@ class OmniLogicMockAPI:
     @overload
     async def async_get_mspconfig(self) -> MSPConfig: ...
     async def async_get_mspconfig(self, raw: bool = False) -> MSPConfig | str:
-        """Return the pre-loaded MSP config from the simulation file."""
+        """Return the pre-loaded MSP config from the current simulation file."""
+        data = self._sim_data[self._index]
+        if self.increment_on_mspconfig:
+            _LOGGER.debug(
+                "Advancing simulation file index from %s to %s, filepath: %s",
+                self._index,
+                (self._index + 1) % len(self._sim_data),
+                data["filepath"],
+            )
+            self._index = (self._index + 1) % len(self._sim_data)
         if raw:
-            return self._mspconfig
-        return MSPConfig.load_xml(self._mspconfig)
+            return data["msp_config"]
+        return MSPConfig.load_xml(data["msp_config"])
 
     @overload
     async def async_get_telemetry(self, raw: Literal[True]) -> str: ...
@@ -69,10 +90,19 @@ class OmniLogicMockAPI:
     @overload
     async def async_get_telemetry(self) -> Telemetry: ...
     async def async_get_telemetry(self, raw: bool = False) -> Telemetry | str:
-        """Return the pre-loaded telemetry from the simulation file."""
+        """Return the pre-loaded telemetry from the current simulation file."""
+        data = self._sim_data[self._index]
+        if self.increment_on_telemetry:
+            _LOGGER.debug(
+                "Advancing simulation file index from %s to %s, filepath: %s",
+                self._index,
+                (self._index + 1) % len(self._sim_data),
+                data["filepath"],
+            )
+            self._index = (self._index + 1) % len(self._sim_data)
         if raw:
-            return self._telemetry
-        return Telemetry.load_xml(self._telemetry)
+            return data["telemetry"]
+        return Telemetry.load_xml(data["telemetry"])
 
     def __getattr__(self, name: str) -> Any:
         """Return a no-op async callable for any API method not explicitly implemented."""


### PR DESCRIPTION
This allows running with an env var such as `PYOMNILOGIC_SIMULATION_DATA=issue-173-1.json,issue-173-2.json` and the library will rotate through the various files with each refresh, allowing testing with data that changes over time.