### PR TITLE
fix: only check telemetry for chlorinator is_on state

### DIFF
--- a/pyomnilogic_local/chlorinator.py
+++ b/pyomnilogic_local/chlorinator.py
@@ -239,7 +239,7 @@ class Chlorinator(OmniEquipment[MSPChlorinator, TelemetryChlorinator]):
         See Also:
             is_generating: Check if actively producing chlorine right now
         """
-        return self.enabled and self.telemetry.enable
+        return self.telemetry.enable
 
     @property
     def is_generating(self) -> bool:


### PR DESCRIPTION
This might fix cryptk/haomnilogic-local#237, but without owning a chlorinator, it's just conjecture.