### PR TITLE
fix(chlorinator): telemetry doesn't properly represent operating mode

### DIFF
--- a/pyomnilogic_local/chlorinator.py
+++ b/pyomnilogic_local/chlorinator.py
@@ -8,7 +8,7 @@ from pyomnilogic_local.collections import EquipmentDict
 from pyomnilogic_local.decorators import control_method
 from pyomnilogic_local.models.mspconfig import MSPChlorinator
 from pyomnilogic_local.models.telemetry import TelemetryChlorinator
-from pyomnilogic_local.omnitypes import ChlorinatorStatus
+from pyomnilogic_local.omnitypes import ChlorinatorMSPConfigMode, ChlorinatorStatus
 from pyomnilogic_local.util import OmniEquipmentNotInitializedError
 
 if TYPE_CHECKING:
@@ -99,8 +99,27 @@ class Chlorinator(OmniEquipment[MSPChlorinator, TelemetryChlorinator]):
         return self.telemetry.operating_state
 
     @property
+    def mode(self) -> ChlorinatorMSPConfigMode:
+        """Current operating mode from MSP Config (NOT_CONFIGURED, TIMED, ORP_AUTO).
+
+        TThis data appears to have some discrepancies with the mode reported in the Telemetry.
+        The assumption is that the MSP Config mode represents the intended/configured mode, while the
+        Telemetry operating mode represents the actual/current mode of operation. The reasons for
+        discrepancies are not fully understood.
+
+        Returns:
+            ChlorinatorMSPConfigMode: The operating mode enum value
+        """
+        return self.mspconfig.mode
+
+    @property
     def operating_mode(self) -> ChlorinatorOperatingMode:
         """Current operating mode (DISABLED, TIMED, ORP_AUTO, or ORP_TIMED_RW).
+
+        This data appears to have some discrepancies with the mode reported in the MSP Config.
+        The assumption is that the MSP Config mode represents the intended/configured mode, while the
+        Telemetry operating mode represents the actual/current mode of operation. The reasons for
+        discrepancies are not fully understood.
 
         Returns:
             ChlorinatorOperatingMode: The operating mode enum value
@@ -402,7 +421,7 @@ class Chlorinator(OmniEquipment[MSPChlorinator, TelemetryChlorinator]):
         )
 
     @control_method
-    async def set_op_mode(self, op_mode: ChlorinatorOperatingMode) -> None:
+    async def set_op_mode(self, op_mode: ChlorinatorMSPConfigMode) -> None:
         """Set the operating mode for chlorine generation.
 
         Args:
@@ -432,12 +451,22 @@ class Chlorinator(OmniEquipment[MSPChlorinator, TelemetryChlorinator]):
 
         bow_type = 0 if bow.equip_type == "BOW_POOL" else 1
 
+        new_op_mode: int
+        match op_mode:
+            case ChlorinatorMSPConfigMode.TIMED:
+                new_op_mode = 1
+            case ChlorinatorMSPConfigMode.ORP_AUTO:
+                new_op_mode = 2
+            case _:
+                msg = f"Unsupported operating mode: {op_mode}"
+                raise ValueError(msg)
+
         await self._api.async_set_chlorinator_params(
             pool_id=self.bow_id,
             equipment_id=self.system_id,
             timed_percent=self.timed_percent_telemetry,
             cell_type=self.mspconfig.cell_type.value,
-            op_mode=op_mode.value,
+            op_mode=new_op_mode,
             sc_timeout=self.superchlor_timeout,
             bow_type=bow_type,
             orp_timeout=self.orp_timeout,

--- a/pyomnilogic_local/models/mspconfig.py
+++ b/pyomnilogic_local/models/mspconfig.py
@@ -20,6 +20,7 @@ from pyomnilogic_local.omnitypes import (
     BodyOfWaterType,
     ChlorinatorCellType,
     ChlorinatorDispenserType,
+    ChlorinatorMSPConfigMode,
     ChlorinatorType,
     ColorLogicLightType,
     ColorLogicShow25,
@@ -217,6 +218,7 @@ class MSPChlorinator(OmniBase):
     omni_type: OmniType = OmniType.CHLORINATOR
 
     enabled: bool = Field(alias="Enabled")
+    mode: ChlorinatorMSPConfigMode = Field(alias="Mode")
     timed_percent: int = Field(alias="Timed-Percent")
     superchlor_timeout: int = Field(alias="SuperChlor-Timeout")
     orp_timeout: int = Field(alias="ORP-Timeout")

--- a/pyomnilogic_local/omnitypes.py
+++ b/pyomnilogic_local/omnitypes.py
@@ -151,6 +151,12 @@ class ChlorinatorError(PrettyEnum, Flag):
     AQUARITE_PCB_ERROR = 1 << 14
 
 
+class ChlorinatorMSPConfigMode(PrettyEnum, StrEnum):
+    DISABLED = "CHLOR_OP_MODE_NOT_CONFIG_R"
+    TIMED = "CHLOR_OP_MODE_TIMED"
+    ORP_AUTO = "CHLOR_OP_MODE_ORP_AUTO"
+
+
 class ChlorinatorOperatingMode(PrettyEnum, IntEnum):
     DISABLED = 0
     TIMED = 1


### PR DESCRIPTION
BREAKING CHANGE: Chlorinator set_op_mode takes ChlorinatorMSPConfigMode instead of ChlorinatorOperatingMode

This is because there seems to be some discrepancy between the mode reported in telemetry and the mode reported in the MSP Config data. The telemetry seems to lag behind the MSP Config, sometimes significantly. Perhaps the MSP Config data is what the requested mode is while the telemetry is what the current mode is, and there is some delay for the system to change modes.