### PR TITLE
fix: get mspconfig checksum from msp config itself

### DIFF
--- a/pyomnilogic_local/models/mspconfig.py
+++ b/pyomnilogic_local/models/mspconfig.py
@@ -432,6 +432,7 @@ class MSPConfig(BaseModel):
     backyard: MSPBackyard = Field(alias="Backyard")
     groups: list[MSPGroup] | None = None
     schedules: list[MSPSchedule] | None = None
+    checksum: int = Field(alias="CHECKSUM")
 
     def __init__(self, **data: Any) -> None:
         # Extract groups from the Groups container if present

--- a/pyomnilogic_local/omnilogic.py
+++ b/pyomnilogic_local/omnilogic.py
@@ -47,7 +47,6 @@ class OmniLogic:
     _api: OmniLogicAPI | OmniLogicMockAPI
     _mspconfig_last_updated: float = 0.0
     _telemetry_last_updated: float = 0.0
-    _mspconfig_checksum: int = 0
     _telemetry_dirty: bool = True
     _refresh_lock: asyncio.Lock
     # This is the minimum supported MSP version for full functionality
@@ -129,7 +128,7 @@ class OmniLogic:
             update_mspconfig = False
             if force_mspconfig:
                 update_mspconfig = True
-            if self.telemetry.backyard.config_checksum != self._mspconfig_checksum:
+            if not hasattr(self, "mspconfig") or self.telemetry.backyard.config_checksum != self.mspconfig.checksum:
                 update_mspconfig = True
 
             if (
@@ -149,7 +148,6 @@ class OmniLogic:
             if update_mspconfig:
                 self.mspconfig = await self._api.async_get_mspconfig()
                 self._mspconfig_last_updated = time.time()
-                self._mspconfig_checksum = self.telemetry.backyard.config_checksum
 
             if update_mspconfig or update_telemetry:
                 self._update_equipment()


### PR DESCRIPTION
Previously, the library assumed that the mspconfig that was pulled had the checksum that was listed in the telemetry data, this is not correct behavior. The MSP Config contains it's own checksum value, and this value is what should be compared to the checksum from the telemetry to determine if we need to re-pull the msp config data or not.