### PR TITLE
fix(api/protocol): correct improper message payload data truncation

### DIFF
--- a/pyomnilogic_local/api/protocol.py
+++ b/pyomnilogic_local/api/protocol.py
@@ -258,7 +258,9 @@ class OmniLogicProtocol(asyncio.DatagramProtocol):
             received_block_count += 1
             _LOGGER.debug("received block %d/%d", received_block_count, lead.msg_block_count)
 
-        return payload_data, compressed
+        # MsgSize identifies the response boundary. Do not strip null bytes from
+        # the payload: they may be valid bytes in a compressed stream's trailer.
+        return payload_data[: lead.msg_size], compressed
 
     def _parse_lead_message(self, msg: OmniLogicMessage) -> LeadMessage:
         """Parse the XML payload of an MSP_LEADMESSAGE into a LeadMessage model.
@@ -284,7 +286,10 @@ class OmniLogicProtocol(asyncio.DatagramProtocol):
             Decoded UTF-8 string with leading/trailing null bytes stripped.
         """
         if compressed:
-            data = zlib.decompress(data.rstrip(b"\x00"))
+            # zlib ignores bytes after the end of a complete stream, so keeping
+            # the wire payload intact preserves a valid trailer that may end in
+            # a null byte while still tolerating protocol padding.
+            data = zlib.decompress(data)
         return data.decode("utf-8").strip("\x00")
 
     # -------------------------------------------------------------------------

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -595,6 +595,46 @@ async def test_receive_file_decompresses_data() -> None:
 
 
 @pytest.mark.asyncio
+async def test_receive_file_decompresses_data_with_protocol_padding() -> None:
+    """Test that valid compressed trailers are not removed with protocol padding."""
+    protocol = OmniLogicProtocol()
+
+    original = b""
+    compressed_data = b""
+    for value in range(256):
+        candidate = b"<STATUS/>" + b"a" * value
+        compressed_candidate = zlib.compress(candidate)
+        if compressed_candidate.endswith(b"\x00"):
+            original = candidate
+            compressed_data = compressed_candidate
+            break
+    else:
+        pytest.fail("Could not create a zlib stream ending in a null byte")
+
+    leadmsg_payload = (
+        '<?xml version="1.0" encoding="UTF-8" ?><Response xmlns="http://nextgen.hayward.com/api"><Name>LeadMessage</Name><Parameters>'
+        '<Parameter name="SourceOpId" dataType="int">1003</Parameter>'
+        f'<Parameter name="MsgSize" dataType="int">{len(compressed_data)}</Parameter>'
+        '<Parameter name="MsgBlockCount" dataType="int">1</Parameter><Parameter name="Type" dataType="int">0</Parameter></Parameters>'
+        "</Response>"
+    )
+    leadmsg = OmniLogicMessage(100, MessageType.MSP_LEADMESSAGE, payload=leadmsg_payload)
+    leadmsg.compressed = True
+
+    block = OmniLogicMessage(101, MessageType.MSP_BLOCKMESSAGE)
+    block.payload = b"\x00" * 8 + compressed_data + b"\x00" * 3
+
+    await protocol._receive_queue.put(leadmsg)
+    await protocol._receive_queue.put(block)
+
+    raw_data, compressed = await protocol._receive_response()
+
+    assert raw_data == compressed_data
+    assert compressed is True
+    assert protocol._decode_payload(raw_data, compressed) == original.decode()
+
+
+@pytest.mark.asyncio
 async def test_receive_file_decompression_error() -> None:
     """Test that _decode_payload raises OmniMessageFormatError for invalid compressed data."""
     protocol = OmniLogicProtocol()


### PR DESCRIPTION
## What changed

Uses the `MsgSize` supplied by an OmniLogic multi-part lead message to trim reassembled response data precisely. It also removes the `rstrip(b"\x00")` call before zlib decompression.

## Why

The previous heuristic could remove a legitimate trailing zero from a compressed stream's zlib trailer and make `zlib.decompress()` raise `Error -5 while decompressing data: incomplete or truncated stream`. The controller already reports the exact message boundary, so there is no need to guess by removing zero bytes.

`zlib.decompress()` tolerates trailing protocol padding after a complete stream while continuing to reject a genuinely truncated stream.

## Validation

- Captured a live controller response: its declared `MsgSize` exactly matched the reassembled compressed response length.
- Added an end-to-end regression test for a compressed stream whose valid trailer ends in `0x00`, followed by protocol padding.
- `pytest -q tests` (full suite)
- Ruff lint and format checks
